### PR TITLE
DGI9-615: Firefox HTTPS/SSL support

### DIFF
--- a/commands/web/playwright
+++ b/commands/web/playwright
@@ -2,6 +2,16 @@
 #ddev-generated
 
 mkcert -install
+cat - > /tmp/playwright-firefox-policies.json <<-EOF
+{
+  "policies": {
+    "Certificates": {
+      "Install": ["$(mkcert -CAROOT)/rootCA.pem"]
+    }
+  }
+}
+EOF
+export PLAYWRIGHT_FIREFOX_POLICIES_JSON=/tmp/playwright-firefox-policies.json
 export NODE_EXTRA_CA_CERTS="$(mkcert -CAROOT)/rootCA.pem"
 export NODE_PATH=$NODE_PATH:$DDEV_COMPOSER_ROOT/test/playwright/node_modules
 cd test/playwright || exit 1


### PR DESCRIPTION
~~Presently contains #1 and #4~~

Should allow Firefox tests to do HTTPS/SSL things, when the `PLAYWRIGHT_FIREFOX_POLICIES_JSON` support is finally a thing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Firefox browser used in automated tests now automatically trusts the root CA certificate, improving compatibility with local HTTPS testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->